### PR TITLE
Add search HTML element

### DIFF
--- a/html-tags.json
+++ b/html-tags.json
@@ -87,6 +87,7 @@
 	"s",
 	"samp",
 	"script",
+	"search",
 	"section",
 	"select",
 	"slot",


### PR DESCRIPTION
Hi there! This adds the `search` HTML element.

On the [WHATWG’s HTML Living Standard Spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element), the `search` element represents a part of a document or application that contains a set of form controls or other content related to performing a search or filtering operation.